### PR TITLE
FAQ Permalink fix, Submenu highlighting, and several img reference fixes

### DIFF
--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -2,7 +2,7 @@
               <ul>
                 <li id="slide-1">
                   <div class="inner">
-                    <span><a href="/features/"><img width="437" height="304" src="http://www.allyourtexts.com/wp-content/uploads/2011/08/conversation_clip.png" class="attachment- size- wp-post-image" alt="Conversation Clip" /></a></span>
+                    <span><a href="/features/"><img width="437" height="304" src="{{site.baseurl}}/images/conversation_clip.png" class="attachment- size- wp-post-image" alt="Conversation Clip" /></a></span>
                     <strong><a href="/features/">View iPhone Conversations on Your PC</a></strong>
                     <ul>
                       <li>View all of your iPhone text (SMS) conversations on your PC</li>
@@ -28,7 +28,7 @@
                 </li>
                 <li id="slide-3">
                   <div class="inner">
-                    <span><a href="/features/"><img width="437" height="304" src="http://www.allyourtexts.com/wp-content/uploads/2011/08/search_clip.png" class="attachment- size- wp-post-image" alt="Search Screenshot Clip" /></a></span>
+                    <span><a href="/features/"><img width="437" height="304" src="{{site.baseurl}}/images/search_clip.png" class="attachment- size- wp-post-image" alt="Search Screenshot Clip" /></a></span>
                     <strong><a href="/features/">Search Instantly</a></strong>
                     <ul>
                       <li>Search all of your iPhone SMS conversations instantly on your PC</li>
@@ -39,7 +39,7 @@
                 </li>
                 <li id="slide-4">
                   <div class="inner">
-                    <span><a href="/features/"><img width="437" height="304" src="http://www.allyourtexts.com/wp-content/uploads/2011/01/graph_clip.png" class="attachment- size- wp-post-image" alt="graph_clip" /></a></span>
+                    <span><a href="/features/"><img width="437" height="304" src="{{site.baseurl}}/images/graph_clip.png" class="attachment- size- wp-post-image" alt="graph_clip" /></a></span>
                     <strong><a href="/features/">Graph Visualizations of All Your Texts</a></strong>
                     <ul>
                       <li>Create graph visualizations of all your iPhone texting behavior</li>

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -16,7 +16,7 @@
                 </li>
                 <li id="slide-2">
                   <div class="inner">
-                    <span><a href="/features/"><img width="437" height="304" src="http://www.allyourtexts.com/wp-content/uploads/2011/10/export_screenshot.png" class="attachment- size- wp-post-image" alt="Export Screenshot" /></a></span>
+                    <span><a href="/features/"><img width="437" height="304" src="{{site.baseurl}}/images/export_screenshot.png" class="attachment- size- wp-post-image" alt="Export Screenshot" /></a></span>
                     <strong><a href="/features/">Export Conversations for Backup</a></strong>
                     <ul>
                       <li>Export individual iPhone conversations or your entire iPhone text history.</li>

--- a/_pages/05-faq.md
+++ b/_pages/05-faq.md
@@ -1,17 +1,18 @@
 ---
 layout: landing
 audience: landingpage
+permalink: /faq/
 breadcrumb: "Support"
 menu-item: true
 has-sub-nav: true
 sub-nav:
     links:
       - text: "FAQ"
-        url:  "/faq"
+        url:  "/faq/"
       - text: "Troubleshooting"
-        url:  "/missing-conversations"
+        url:  "/missing-conversations/"
       - text: "Report an Issue"
-        url:  "/report-issue"
+        url:  "/report-issue/"
 ---
 
 <div class="page type-page status-publish hentry">


### PR DESCRIPTION
There were 3 issues identified today and the fixes included here resolve 2 of the 3.  The third, issue I have a couple questions on however and wondering how best to handle a couple cases.
- [x] FAQ page url is not correct.  - This issue is resolved with this pull request as you were right that this page was missing the permalink.  I added the permalink into the _pages/05-faq.md file, so the URL is corrected and displays as /faq/
- [x] Submenu highlighting not working - This issue is also resolved with this pull request.  The logic for the dynamic menus is correct in the _includes/header.html file, however, the links for the submenu pages identified in the _pages/05-faq.md file were missing the trailing slash.  Adding that in allows the logic in the _includes/header.html file to correctly equate the current page with the stored subheader links.  Additionally, having the trailing slash here is more correct and should render these submenu pages slightly quicker.
- [ ] Several image/link references to old AllYourText website - This pull request fixes the image references identified in the _includes/slider.html file.  However, there are still a couple of places where there is the legacy link and want to make sure we handle them properly before fixing.
  1.  In the _includes/slider.html file there are a few links that I can't see on the current site, so wonder if we can remove them altogether?  It looks like they are linking to pages that maybe shouldn't exist as there isn't much on them?  If we need to keep them, I think we will need to add a few more md files into the _pages directory.  Below is an example of one of these links (on line 13), do you know if this is doing anything or supposed to be there?
     <img width="979" alt="screen shot 2016-01-19 at 9 30 00 pm" src="https://cloud.githubusercontent.com/assets/2396774/12438385/45c74c5c-bef4-11e5-9db7-289fa00fd434.png">
  2.  In the _pages/privacy-policy.md file there is some content/link in there pointing to the old website.  Should I just change those links to: http://allyourtexts.github.io/  I assume that is desired, but please let me know if that is not the case?
