### PR TITLE
Travis Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: ruby
+ rvm:
+   - 2.1
+ script:
+   - bundle exec jekyll build --config _config_dev.yml
+   - bundle exec htmlproof ./_site --only-4xx --check-html
+ # branch whitelist, only for GitHub Pages
+ branches:
+   only:
+   - gh-pages
+   - master
+ env:
+   global:
+     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 language: ruby
- rvm:
-   - 2.1
- script:
-   - bundle exec jekyll build --config _config_dev.yml
-   - bundle exec htmlproof ./_site --only-4xx --check-html
- # branch whitelist, only for GitHub Pages
- branches:
-   only:
-   - gh-pages
-   - master
- env:
-   global:
-     - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
+rvm:
+  - 2.1
+script:
+  - bundle exec jekyll build --config _config_dev.yml
+  - bundle exec htmlproof ./_site --only-4xx --check-html
+# branch whitelist, only for GitHub Pages
+branches:
+  only:
+  - gh-pages
+  - master
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ versions = JSON.parse(open('https://pages.github.com/versions.json').read)
 
 gem 'github-pages', versions['github-pages']
 gem 'rdiscount'
-gem 'json'
 gem 'liquid'
 gem 'jekyll'
-
+gem 'html-proofer'

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -25,7 +25,7 @@
             <ul class="xoxo">
               <li id="text-4" class="widget-container widget_text">
                 <div class="textwidget"><span>AllYourTexts Software &copy; 2016</span> | <a href="{{site.baseurl}}/privacy-policy/">Privacy Policy</a><br/>
-                  <a href="https://www.facebook.com/AllYourTexts" onclick="_gaq.push(['_trackEvent', 'outbound-widget', 'https://www.facebook.com/AllYourTexts', '']);" target="_blank"><img src="{{site.baseurl}}/images/find-us-on-facebook_logo.gif" style="padding-top:18px; width: 170px;" /></a>
+                  <a href="https://www.facebook.com/AllYourTexts" onclick="_gaq.push(['_trackEvent', 'outbound-widget', 'https://www.facebook.com/AllYourTexts', '']);" target="_blank"><img src="{{site.baseurl}}/images/find-us-on-facebook_logo.gif" style="padding-top:18px; width: 170px;" alt="Facebook Logo"/></a>
                 </div>
               </li>
             </ul>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -7,7 +7,7 @@
         <div id="branding" role="banner">
           <h1 id="site-title">
             <span>
-            <a href="{{site.baseurl}}/" title="AllYourTexts" rel="home"><img src="{{site.basurl}}/images/logo.png" title="" alt="" /></a>
+            <a href="{{site.baseurl}}/" title="AllYourTexts" rel="home"><img src="{{site.basurl}}/images/logo.png" title="" alt="AllYourTexts Logo" /></a>
             </span>
           </h1>
         </div>
@@ -26,7 +26,7 @@
             {% for page in site.pages %}
               {% if page.menu-item %}
                 <li class="menu-item menu-item-type-post_type menu-item-object-page {% if page.url == currentPg %}current-menu-item current_page_item{% endif %}">
-                  <a href='{% if page.breadcrumb == "github" %}{{site.url_GitHub}}{% else %}{{site.baseurl}}{{page.url}}{% endif %}' {% if page.breadcrumb == "github" %}onclick="_gaq.push(['_trackEvent', 'outbound-widget', 'https://github.com/AllYourTexts/AllYourTexts', 'Github']);{% endif %}">{{page.breadcrumb}}</a>
+                  <a href='{% if page.breadcrumb == "github" %}{{site.url_GitHub}}{% else %}{{site.baseurl}}{{page.url}}{% endif %}' {% if page.breadcrumb == "github" %}onclick="_gaq.push(['_trackEvent', 'outbound-widget', 'https://github.com/AllYourTexts/AllYourTexts', 'Github']);"{% endif %}>{{page.breadcrumb}}</a>
 
                 {% if page.sub-nav %}
                 <ul class="sub-menu">

--- a/_includes/slider.html
+++ b/_includes/slider.html
@@ -46,6 +46,6 @@
                   </div>
                 </li>
               </ul>
-              <a href="#" class="prev"></a>
-              <a href="#" class="next"></a>
+              <a href="#" class="prev" data-proofer-ignore></a>
+              <a href="#" class="next" data-proofer-ignore></a>
             </div>


### PR DESCRIPTION
This pull request completes the implementation of Travis into the AllYourTexts codebase.

**The admin of this repo will need to enable Travis to build and run the HTML proofer tests to complete this integration.**

This tests out locally however and in doing so, it identified a handful of issues that this PR also fixes:
- [x] Added alt tag to AllYourTexts logo in the header
- [x] Added alt tag to Facebook logo in the footer
- [x] incorrect placement of attribute double quote in nav menu
- [x] The HTML validator also identified the slider next/prev buttons as having an unlickable href, however, it is intended to have that as just a hash tag "#" as it shouldn't link to anything, but merely advance the slider forward or backward.  To solve this issue and ensure it is not flagged in the future, added a "data-proofer-ignore" attribute to those links to have the validator ignore those.

Finally, also tweaked the Gemfile to remove an extra gem for "json".

Testing the Travis integration on "test" repo, can now see a clean build with 0 errors flagged.
<img width="968" alt="screen shot 2016-01-29 at 10 00 21 pm" src="https://cloud.githubusercontent.com/assets/2396774/12693308/a95aa740-c6d4-11e5-8ba3-32816296d8ab.png">
